### PR TITLE
Removed ports from Tautulli config

### DIFF
--- a/tautulli/docker-compose.yml
+++ b/tautulli/docker-compose.yml
@@ -41,8 +41,6 @@ services:
       - TZ=Europe/Amsterdam   
     volumes:
       - /mnt/tautulli:/config
-    ports:
-      - 8181:8181
     depends_on:
       - tailscale-tautulli
     healthcheck:


### PR DESCRIPTION
Please add this to the effective PR to remove ports. The ports will not work since Tailscale Sidecar is used.